### PR TITLE
fix one-to-one relationship carts-users

### DIFF
--- a/src/main/java/com/alumnione/ecommerce/entity/Cart.java
+++ b/src/main/java/com/alumnione/ecommerce/entity/Cart.java
@@ -35,10 +35,7 @@ public class Cart {
     @Column(name = "last_updated")
     private LocalDateTime lastUpdated;
 
-    //TODO: remove this!!!
-    @JsonIgnore //error (user -> order -> invoice) SQL Error: 1146, SQLState: 42S02, Table 'ecommerce_backend_local.invoice' doesn't exist
-    @OneToOne(orphanRemoval = true)
+    @OneToOne(fetch=FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name = "user_id")
     private User user;
-
 }

--- a/src/main/resources/db/migration/V12__alter_table_carts_delete_fk_user_id.sql
+++ b/src/main/resources/db/migration/V12__alter_table_carts_delete_fk_user_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE carts
+    MODIFY user_id BIGINT NOT NULL UNIQUE;

--- a/src/main/resources/db/migration/V13__alter_table_users_alter_fk_cart_id.sql
+++ b/src/main/resources/db/migration/V13__alter_table_users_alter_fk_cart_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users
+               DROP FOREIGN KEY users_carts_id_cart_fk;
+ALTER TABLE users
+               DROP COLUMN cart_id;
+


### PR DESCRIPTION
relationship carts-users antes de este pull request, carts y users tienen un foreign key referenciandose mutuamente:
![image](https://github.com/AlumniONE/ecommerce-backend/assets/73559673/2ff54609-e7ac-4093-adfc-5e9aa78ebf49)

basandome el este [blog](https://www.tech-recipes.com/database/one-to-one-one-to-many-table-relationships-in-sql-server/), en [este ](https://dotnettutorials.net/lesson/database-relationships-in-mysql/)y en [stackexchange](https://dba.stackexchange.com/a/118377), elimine el **foreign key cart_id** de la tabla **users** y cambie el data type de **user_id** de la tabla **carts**
relationship carts-users:
![image](https://github.com/AlumniONE/ecommerce-backend/assets/73559673/19310c0a-d5ce-4371-8082-572404d25f12)


con eso tambien se arreglo el error `SQL Error: 1146, SQLState: 42S02, Table 'ecommerce_backend_local.invoice' doesn't exist` en la entidad **Cart**