### PR TITLE
chore: change spring.jpa.hibernate.ddl-auto from create to update in properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.type=trace
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Improve performance by avoiding unnecessary database recreation on each startup. With 'update', the database will be created once and only updated if there are changes.